### PR TITLE
BP-2553 | Allow app to pass base_url

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -31,7 +31,7 @@ inputs:
     default: canary
   base_url:
     description: interpolated before the main url. for apps that start from gateways
-    required: true
+    required: false
     default: ''
 runs:
   using: docker

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,10 @@ inputs:
     description: deployment environment name
     required: false
     default: canary
+  base_url:
+    description: interpolated before the main url. for apps that start from gateways
+    required: true
+    default: ''
 runs:
   using: docker
   image: Dockerfile

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,9 +22,10 @@ async function run() {
     const buildCmd = core.getInput('build_cmd', { required: true });
     const deployEnv = core.getInput('deploy_env', { required: true });
     const skipEnvUpdate = core.getInput('skip_env_update');
+    const base_url = core.getInput('base_url');
     const destination = `s3://${bucket}/${projectName}-${prNum}/`;
 
-    const url = `https://${projectName}-${prNum}.canary.alpha.boldpenguin.com`;
+    const url = `${base_url}https://${projectName}-${prNum}.canary.alpha.boldpenguin.com`;
 
     process.chdir('/github/workspace');
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,7 +21,7 @@ async function run() {
     const projectName = core.getInput('project_name') || repo;
     const buildCmd = core.getInput('build_cmd', { required: true });
     const deployEnv = core.getInput('deploy_env', { required: true });
-    const base_url = core.getInput('base_url', required: true);
+    const base_url = core.getInput('base_url', { required: true });
     const skipEnvUpdate = core.getInput('skip_env_update');
     const destination = `s3://${bucket}/${projectName}-${prNum}/`;
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,7 +21,7 @@ async function run() {
     const projectName = core.getInput('project_name') || repo;
     const buildCmd = core.getInput('build_cmd', { required: true });
     const deployEnv = core.getInput('deploy_env', { required: true });
-    const base_url = core.getInput('base_url', { required: true });
+    const base_url = core.getInput('base_url');
     const skipEnvUpdate = core.getInput('skip_env_update');
     const destination = `s3://${bucket}/${projectName}-${prNum}/`;
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,8 +21,8 @@ async function run() {
     const projectName = core.getInput('project_name') || repo;
     const buildCmd = core.getInput('build_cmd', { required: true });
     const deployEnv = core.getInput('deploy_env', { required: true });
+    const base_url = core.getInput('base_url', required: true);
     const skipEnvUpdate = core.getInput('skip_env_update');
-    const base_url = core.getInput('base_url');
     const destination = `s3://${bucket}/${projectName}-${prNum}/`;
 
     const url = `${base_url}https://${projectName}-${prNum}.canary.alpha.boldpenguin.com`;


### PR DESCRIPTION
progressive needs the redirect url in the form of 

```
https://progressivegateway.alpha.boldpenguin.com/?redirectUrl=https:%2F%2Fprogressive-portal-320.canary.alpha.boldpenguin.com
```

This allow us to safety interpolate in the gateway URL.

[x] This works for progressive portal: https://github.com/BoldPenguin/progressive-portal/pull/322
[x] This works for IA and NW portals: https://github.com/BoldPenguin/pqi/pull/286