### PR TITLE
BP-4548: Allow canary on branch

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,10 @@ inputs:
     description: interpolated before the main url. for apps that start from gateways
     required: false
     default: ''
+  use_ref:
+    description: Use the ref rather than the PR number. This is intended when canary builds are done on every merge to a branch
+    required: false
+    default: false
 runs:
   using: docker
   image: Dockerfile

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,7 +14,10 @@ async function run() {
     const githubToken = core.getInput('github_token');
     const context = github.context;
     const repo = context.repo.repo;
-    const ref = (context.ref || '').replace(/\//g, '-').replace(/\\/gi,'-');
+    const ref = (context.ref || '')
+                .replace(/\//g, '-')
+                .replace(/\\/g,'-')
+                .toLowerCase();
     console.log(`ref: ${ref}`);
     const prNum = context.issue.number;
     console.log(`prNum: ${prNum}`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,9 +18,7 @@ async function run() {
                 .replace(/\//g, '-')
                 .replace(/\\/g,'-')
                 .toLowerCase();
-    console.log(`ref: ${ref}`);
     const prNum = context.issue.number;
-    console.log(`prNum: ${prNum}`);
     const bpToken = core.getInput('bp_github_token', { required: true });
     const bucket = core.getInput('bucket', { required: true });
     const dist_dir = core.getInput('dist_dir', { required: true });

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,7 +14,7 @@ async function run() {
     const githubToken = core.getInput('github_token');
     const context = github.context;
     const repo = context.repo.repo;
-    const ref = context.ref;
+    const ref = context.ref.replace('/', '-').replace('\\', '-');
     const prNum = context.issue.number;
     const bpToken = core.getInput('bp_github_token', { required: true });
     const bucket = core.getInput('bucket', { required: true });

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,8 +14,11 @@ async function run() {
     const githubToken = core.getInput('github_token');
     const context = github.context;
     const repo = context.repo.repo;
-    const ref = context.ref.replace('/', '-').replace('\\', '-');
+    const ref = (context.ref || '').replace('/', '-').replace('\\', '-');
+    const pr_ref = 
+    console.log(`ref: ${ref}`);
     const prNum = context.issue.number;
+    console.log(`prNum: ${prNum}`);
     const bpToken = core.getInput('bp_github_token', { required: true });
     const bucket = core.getInput('bucket', { required: true });
     const dist_dir = core.getInput('dist_dir', { required: true });
@@ -42,7 +45,7 @@ async function run() {
     core.startGroup('Create Deployment');
       const deployOpts: ReposCreateDeploymentParams  = {
         ...context.repo,
-        ref: context.payload.pull_request.head.sha,
+        ref: context.payload.pull_request ? context.payload.pull_request.head.sha : context.sha,
         task: 'canary',
         environment: deployEnv,
         transient_environment: true,

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,6 +14,7 @@ async function run() {
     const githubToken = core.getInput('github_token');
     const context = github.context;
     const repo = context.repo.repo;
+    const ref = context.ref;
     const prNum = context.issue.number;
     const bpToken = core.getInput('bp_github_token', { required: true });
     const bucket = core.getInput('bucket', { required: true });
@@ -24,9 +25,15 @@ async function run() {
     const base_url = core.getInput('base_url');
     const skipEnvUpdate = core.getInput('skip_env_update');
     const workingDir = core.getInput('working_dir');
-    const destination = `s3://${bucket}/${projectName}-${prNum}/`;
+    const useRefForDestination = core.getInput('use_ref');
 
-    const url = `${base_url}https://${projectName}-${prNum}.canary.alpha.boldpenguin.com`;
+    const destination = useRefForDestination ? 
+                          `s3://${bucket}/${projectName}-${ref}/` :
+                          `s3://${bucket}/${projectName}-${prNum}/`;
+
+    const url = useRefForDestination ? 
+                  `${base_url}https://${projectName}-${ref}.canary.alpha.boldpenguin.com` :
+                  `${base_url}https://${projectName}-${prNum}.canary.alpha.boldpenguin.com`;
 
     process.chdir('/github/workspace');
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,10 +14,14 @@ async function run() {
     const githubToken = core.getInput('github_token');
     const context = github.context;
     const repo = context.repo.repo;
-    const ref = (context.ref || '')
-                .replace(/\//g, '-')
-                .replace(/\\/g,'-')
-                .toLowerCase();
+    let ref = context.ref || '';
+    if (ref.startsWith('refs/heads/')) {
+      ref = ref.slice('refs/heads/'.length);
+    }
+    ref = ref
+          .replace(/\//g, '-')
+          .replace(/\\/g,'-')
+          .toLowerCase();
     const prNum = context.issue.number;
     const bpToken = core.getInput('bp_github_token', { required: true });
     const bucket = core.getInput('bucket', { required: true });
@@ -30,13 +34,9 @@ async function run() {
     const workingDir = core.getInput('working_dir');
     const useRefForDestination = core.getInput('use_ref');
 
-    const destination = useRefForDestination ? 
-                          `s3://${bucket}/${projectName}-${ref}/` :
-                          `s3://${bucket}/${projectName}-${prNum}/`;
-
-    const url = useRefForDestination ? 
-                  `${base_url}https://${projectName}-${ref}.canary.alpha.boldpenguin.com` :
-                  `${base_url}https://${projectName}-${prNum}.canary.alpha.boldpenguin.com`;
+    const bucketRef = useRefForDestination ? ref : prNum;
+    const destination = `s3://${bucket}/${projectName}-${bucketRef}/`;
+    const url = `${base_url}https://${projectName}-${bucketRef}.canary.alpha.boldpenguin.com`;
 
     process.chdir('/github/workspace');
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,8 +14,7 @@ async function run() {
     const githubToken = core.getInput('github_token');
     const context = github.context;
     const repo = context.repo.repo;
-    const ref = (context.ref || '').replace('/', '-').replace('\\', '-');
-    const pr_ref = 
+    const ref = (context.ref || '').replace(/\//g, '-').replace(/\\/gi,'-');
     console.log(`ref: ${ref}`);
     const prNum = context.issue.number;
     console.log(`prNum: ${prNum}`);


### PR DESCRIPTION
In support of CI / CD for the terminal 2.0 project, allow canary builds based on a ref, rather than just a Pull Request