### PR TITLE
Add alpine-sdk to build binary modules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:alpine
 
-RUN apk add --no-cache jq npm git yarn
+RUN apk add --no-cache jq npm git yarn alpine-sdk
 
 RUN pip install awscli
 


### PR DESCRIPTION
Need build tools to compile docusaurus for bp-developers canary builds. Hoping this is sufficient.

