### PR TITLE
Allow for skipping `npm ci` so we can cache dependencies

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -40,6 +40,10 @@ inputs:
     description: Use the ref rather than the PR number. This is intended when canary builds are done on every merge to a branch
     required: false
     default: ''
+  skip_install:
+    description: Don't attempt to install dependecies with `npm ci`. Use this if you are sure the dependencies are already available via cache
+    required: false
+    default: ''
 runs:
   using: docker
   image: Dockerfile

--- a/src/main.ts
+++ b/src/main.ts
@@ -33,6 +33,7 @@ async function run() {
     const skipEnvUpdate = core.getInput('skip_env_update');
     const workingDir = core.getInput('working_dir');
     const useRefForDestination = core.getInput('use_ref');
+    const skipInstall = core.getInput('skip_install');
 
     const bucketRef = useRefForDestination ? ref : prNum;
     const destination = `s3://${bucket}/${projectName}-${bucketRef}/`;
@@ -83,13 +84,15 @@ async function run() {
       core.endGroup();
     }
 
-    core.startGroup('Install dependencies')
-    if (existsSync('./yarn.lock')) {
-      await exec.exec('yarn');
-    } else {
-      await exec.exec('npm', ['ci', '--unsafe-perm']);
+    if (!skipInstall) {
+      core.startGroup('Install dependencies')
+      if (existsSync('./yarn.lock')) {
+        await exec.exec('yarn');
+      } else {
+        await exec.exec('npm', ['ci', '--unsafe-perm']);
+      }
+      core.endGroup();
     }
-    core.endGroup();
 
     core.startGroup('Build')
     await exec.exec('npm', ['run', buildCmd]);


### PR DESCRIPTION
Unfortunately, ngcc is slow. Like, really slow. So slow that for terminal, it was taking ~ 8 minutes of the 11 minute canary deploy time just to run ngcc. 

See https://github.com/angular/angular/issues/37297 for more details...

Rather than wait for ngcc to speed up, we can actually speed up times significantly by caching dependencies. This change to canary-action just let's the external caller indicate that they have restored dependencies from a cache and don't want this action to call `npm ci`. In general, this input should be mapped to the `cache-hit` property of the `cache` action. 

For an example of how this is being used and working, see: https://github.com/BoldPenguin/terminal/blob/feat/BP-4825-business-info-styling/.github/workflows/canary-build.yml#L36

After implementing this, the build time for a terminal canary build with a cache hit went from ~11 minutes to ~3 minutes 🎉 