### PR TITLE
Fix permissions after running

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:alpine
 
-RUN apk add --no-cache jq npm git yarn g++ make nasm autoconf automake
+RUN apk add --no-cache coreutils jq npm git yarn g++ make nasm autoconf automake
 
 RUN pip install awscli
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,8 @@
 #!/bin/sh -l
 
+fixperms() {
+    chown -R `stat --printf=%u /github/workspace/.` /github/workspace/*
+}
+trap fixperms EXIT
+
 node /canary/lib/main.js


### PR DESCRIPTION
When running on self-hosted runner, you aren't necessarily running as `root`. However, every file created within the docker container is owned by root. This then makes it impossible for other non-docker jobs to modify.

This adds a trap to the entrypoint to change the ownership of all workspace files to the uid:gid of the runner.

https://github.com/actions/checkout/issues/273#issuecomment-733350224